### PR TITLE
Added placeholders to the docs for the workflows

### DIFF
--- a/sphinx/source/workflows/acessing-postgis-from-qgis-using-pg_service-file.md
+++ b/sphinx/source/workflows/acessing-postgis-from-qgis-using-pg_service-file.md
@@ -1,0 +1,9 @@
+# Accessing PostGIS from QGIS using a pg_service file
+
+This workflow will demonstrate the following:
+
+* Setting up your Postgres connection
+* Loading data into the Postgres database
+* Creating the connection
+* Creating the pg_service file
+* Using the pg_service file on the client side of the stack (where it references the external port) and the server side (where it references the internal port)

--- a/sphinx/source/workflows/authentication-using-pg_service-and-qgisauthdb.md
+++ b/sphinx/source/workflows/authentication-using-pg_service-and-qgisauthdb.md
@@ -1,0 +1,3 @@
+# Authentication of Postgres using a pg_service file and a qgis-auth.db file
+
+This workflow will demonstrate how to access Postgres in QGIS using a pg_service file and a qgis-auth.db file.

--- a/sphinx/source/workflows/connecting-to-geoserver-and-qgisserver-in-hugo.md
+++ b/sphinx/source/workflows/connecting-to-geoserver-and-qgisserver-in-hugo.md
@@ -1,0 +1,7 @@
+# Connecting to Geoserver and QGIS Server in Hugo
+
+This workflow covers connecting to QGIS server and Geoserver in Hugo through the following steps:
+
+* Creating a new map file pointing to the service URL
+* Specifying the layers you want
+* Adding any surrounding text and information for the service

--- a/sphinx/source/workflows/create-osm-mirror-in-database.md
+++ b/sphinx/source/workflows/create-osm-mirror-in-database.md
@@ -1,0 +1,1 @@
+# Creating an Open Street Map mirror into your database

--- a/sphinx/source/workflows/index.rst
+++ b/sphinx/source/workflows/index.rst
@@ -8,6 +8,7 @@ Workflows
    publishing-changes-to-static-website
    uploading-qgis-project
    acessing-postgis-from-qgis-using-pg_service-file
+   authentication-using-pg_service-and-qgisauthdb
    postgresql-workflows
 
 

--- a/sphinx/source/workflows/index.rst
+++ b/sphinx/source/workflows/index.rst
@@ -9,6 +9,8 @@ Workflows
    uploading-qgis-project
    acessing-postgis-from-qgis-using-pg_service-file
    authentication-using-pg_service-and-qgisauthdb
+   publishing-qgis-project
+   publishing-layers-using-geoserver
    postgresql-workflows
 
 

--- a/sphinx/source/workflows/index.rst
+++ b/sphinx/source/workflows/index.rst
@@ -11,6 +11,7 @@ Workflows
    authentication-using-pg_service-and-qgisauthdb
    publishing-qgis-project
    publishing-layers-using-geoserver
+   connecting-to-geoserver-and-qgisserver-in-hugo
    postgresql-workflows
 
 

--- a/sphinx/source/workflows/index.rst
+++ b/sphinx/source/workflows/index.rst
@@ -6,6 +6,7 @@ Workflows
    :caption: Contents:
 
    publishing-changes-to-static-website
+   uploading-qgis-project
    postgresql-workflows
 
 

--- a/sphinx/source/workflows/index.rst
+++ b/sphinx/source/workflows/index.rst
@@ -13,6 +13,15 @@ Workflows
    publishing-layers-using-geoserver
    connecting-to-geoserver-and-qgisserver-in-hugo
    qgis-desktop-as-web-service-client
+   node-red-access-data-in-postgres
+   postgrest-api
+   node-red-postgrest-api
+   node-red-point-layer-to-worldmap
+   set-up-pg-notify
+   mergin-db-sync-client-workflow1
+   mergin-db-sync-client-workflow2
+   create-osm-mirror-in-database
+   osm-enrich-workflow
    postgresql-workflows
 
 

--- a/sphinx/source/workflows/index.rst
+++ b/sphinx/source/workflows/index.rst
@@ -7,6 +7,7 @@ Workflows
 
    publishing-changes-to-static-website
    uploading-qgis-project
+   acessing-postgis-from-qgis-using-pg_service-file
    postgresql-workflows
 
 

--- a/sphinx/source/workflows/index.rst
+++ b/sphinx/source/workflows/index.rst
@@ -12,6 +12,7 @@ Workflows
    publishing-qgis-project
    publishing-layers-using-geoserver
    connecting-to-geoserver-and-qgisserver-in-hugo
+   qgis-desktop-as-web-service-client
    postgresql-workflows
 
 

--- a/sphinx/source/workflows/index.rst
+++ b/sphinx/source/workflows/index.rst
@@ -5,6 +5,7 @@ Workflows
    :maxdepth: 2
    :caption: Contents:
 
+   publishing-changes-to-static-website
    postgresql-workflows
 
 

--- a/sphinx/source/workflows/mergin-db-sync-client-workflow1.md
+++ b/sphinx/source/workflows/mergin-db-sync-client-workflow1.md
@@ -1,0 +1,7 @@
+# Mergin-db-sync client workflow 1
+
+This workflow will demonstrate how to:
+
+* Create a project in QGIS
+* Publish it to Mergin
+* Synchronize the published project into your Postgres database schema

--- a/sphinx/source/workflows/mergin-db-sync-client-workflow2.md
+++ b/sphinx/source/workflows/mergin-db-sync-client-workflow2.md
@@ -1,0 +1,6 @@
+# Mergin-db-sync client Workflow 2
+
+This workflow will demonstrate how to:
+
+* Create a QGIS project with data in Postgres
+* Tell Mergin to generate a geopackage and push the geopackage out to the Mergin server

--- a/sphinx/source/workflows/node-red-access-data-in-postgres.md
+++ b/sphinx/source/workflows/node-red-access-data-in-postgres.md
@@ -1,0 +1,3 @@
+# Node-red workflow that accesses data in Postgres
+
+This is a simple workflow where you connect to a table in Postgres, select all the rows in the table and put them into a table in a dashboard in node red.

--- a/sphinx/source/workflows/node-red-point-layer-to-worldmap.md
+++ b/sphinx/source/workflows/node-red-point-layer-to-worldmap.md
@@ -1,0 +1,3 @@
+# Node-red point layer to world map
+
+This workflow demonstrates how to take a point layer and connect to it using either the PostgREST API or via Postgres connection, get the points and some data for each point and push them through to the world map in node-red, to create a web map based on live data in the database. 

--- a/sphinx/source/workflows/node-red-postgrest-api.md
+++ b/sphinx/source/workflows/node-red-postgrest-api.md
@@ -1,0 +1,3 @@
+## Node-red connect to the PostgREST API
+
+This workflow will demonstrate how to connect to the PostgREST API, pull data out of  table and present it in a node-red dahsboard.

--- a/sphinx/source/workflows/osm-enrich-workflow.md
+++ b/sphinx/source/workflows/osm-enrich-workflow.md
@@ -1,0 +1,3 @@
+# OSM enrich workflow
+
+This workflow will demonstrate how to use osm-enrich to add a timestamp and the user name for every feature being pulled from Open Street Map.

--- a/sphinx/source/workflows/postgrest-api.md
+++ b/sphinx/source/workflows/postgrest-api.md
@@ -1,0 +1,6 @@
+# PostgREST API
+
+This workflow will demonstrate how to:
+
+* Publish layers from a Postgres schema into the PostgREST API
+* Use swagger in the web browser to go and discover the published services there

--- a/sphinx/source/workflows/publishing-changes-to-static-website.md
+++ b/sphinx/source/workflows/publishing-changes-to-static-website.md
@@ -1,0 +1,3 @@
+# Publishing changes to the static website
+
+This workflow shows how to publish changes to the static website using the SCP containers and the Hugo content SCP folder labelled hugo_data, by editing a document locally then pushing the changes up.

--- a/sphinx/source/workflows/publishing-layers-using-geoserver.md
+++ b/sphinx/source/workflows/publishing-layers-using-geoserver.md
@@ -1,0 +1,8 @@
+# Publishing layers using Geoserver
+
+This workflow will demonstrate the following:
+
+* Basic configuration of Geoserver using a shapefile store (a directory of shapefiles)
+* Uploading one or more shapefiles to the server using the scp drop zone for Geoserver
+* Registering the layers
+* Publishing the layers as basic WMS layers

--- a/sphinx/source/workflows/publishing-qgis-project.md
+++ b/sphinx/source/workflows/publishing-qgis-project.md
@@ -1,0 +1,4 @@
+# Publishing a QGIS project
+
+This workflow will demonstrate how to publish a QGIS project where the layers are inside of Postgres. 
+This involves uploading a QGIS project file through the pg_service file and or qgis-auth.db for authentication then publishing the map.

--- a/sphinx/source/workflows/qgis-desktop-as-web-service-client.md
+++ b/sphinx/source/workflows/qgis-desktop-as-web-service-client.md
@@ -1,0 +1,3 @@
+# QGIS Desktop as a Web Services Client
+
+This workflow will cover how to use QGIS Desktop as a web service client for both the QGIS Server and Geoserver published layers.

--- a/sphinx/source/workflows/set-up-pg-notify.md
+++ b/sphinx/source/workflows/set-up-pg-notify.md
@@ -1,0 +1,7 @@
+# Set up process for pg notify
+
+Pg notify is a notification system that Postgres has that can let a client know that a change has occurred in the database. This workflow will demonstrate how to: 
+
+* Register the notification function
+* Push out the message to a client (we will start with QGIS as the client)
+* Have QGIS automatically update and refresh the canvas when a notification happens

--- a/sphinx/source/workflows/uploading-qgis-project.md
+++ b/sphinx/source/workflows/uploading-qgis-project.md
@@ -1,0 +1,8 @@
+# Uploading a QGIS project
+
+The steps to be demonstrated in this workflow are:
+* Creating a shapefile
+* Creating a QGIS project file
+* Putting the QGIS project file in a named directory that matches the name of QGIS project file
+* Uploading the folder containing the QGIS project to the SCP folder for QGIS projects
+* Accessing the QGIS project on the OGC link


### PR DESCRIPTION
Added place holders to the docs for the following workflows:

- Accessing PostGIS from QGIS using a pg_service file
- Authentication of Postgres using a pg_service file and a qgis-auth.db file
- Connecting to Geoserver and QGIS Server in Hugo
- Creating an Open Street Map mirror into your database
- Mergin-db-sync client workflow 1
- Mergin-db-sync client workflow 2
- Node-red workflow that accesses data in Postgres
- Node-red point layer to world map
- Node-red connect to the PostgREST API
- OSM enrich workflow
- PostgREST API
- Publishing changes to the static website
- Publishing layers using Geoserver
- Publishing a QGIS project
- QGIS Desktop as a Web Services Client
- Set up process for pg notify
- Uploading a QGIS project